### PR TITLE
Clean up POM

### DIFF
--- a/source/pom.xml
+++ b/source/pom.xml
@@ -38,9 +38,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.8</version>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -69,7 +69,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <encoding>${source.encoding}</encoding>
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
@@ -89,6 +88,11 @@
                         </manifest>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.8</version>
             </plugin>
             <!-- dependencies to jar -->
             <plugin>


### PR DESCRIPTION
This commit cleans up the POM. It contains the following changes:

- the Javadoc plugin should not be a dependency, use commons-lang
  instead
- the compiler plugin defaults to ${project.build.sourceEncoding}